### PR TITLE
Fix of the format command

### DIFF
--- a/project_name/startup.py
+++ b/project_name/startup.py
@@ -10,7 +10,7 @@ def autoload(submodules):
         mod = import_module(app)
         for submodule in submodules:
             try:
-                import_module("{}.{}".format(app, submodule))
+                import_module("{0}.{1}".format(app, submodule))
             except:
                 if module_has_submodule(mod, submodule):
                     raise


### PR DESCRIPTION
Error when running syncdb 

import_module("{}.{}".format(app, submodule))
ValueError: zero length field name in format
