### PR TITLE
Fix spacing between navbar and main container

### DIFF
--- a/project_name/templates/site_base.html
+++ b/project_name/templates/site_base.html
@@ -6,8 +6,8 @@
 
 
 {% block style_base %}
-    <link href="{% static "pinax/css/theme.css" %}" rel="stylesheet">
     <link href="{% static "css/site.css" %}" rel="stylesheet">
+    <link href="{% static "pinax/css/theme.css" %}" rel="stylesheet">
     {% block extra_style %}{% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
The navbar and the main container have no spacing between them.  On  /account/settings/ the settings panel is actually touching the navbar.  This issue was further exaggerated after loading a theme from bootswatch.

It appears that theme.css is meant to make an adjustment to put the main container in the correct place.  It does that job as long as it is loaded AFTER site.css.  In it's current place on 4c501b8 theme.css doesn't appear to do anything.